### PR TITLE
Adding Allowlisted Plugins via .env

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -175,3 +175,10 @@ TW_CONSUMER_KEY=
 TW_CONSUMER_SECRET=
 TW_ACCESS_TOKEN=
 TW_ACCESS_TOKEN_SECRET=
+
+################################################################################
+### ALLOWLISTED PLUGINS
+################################################################################
+
+#ALLOWLISTED_PLUGINS - Sets the listed plugins that are allowed (Example: plugin1,plugin2,plugin3)
+ALLOWLISTED_PLUGINS=

--- a/README.md
+++ b/README.md
@@ -264,7 +264,11 @@ Drop the repo's zipfile in the plugins folder.
 
 ![Download Zip](https://raw.githubusercontent.com/BillSchumacher/Auto-GPT/master/plugin.png)
 
-If you add the plugins class name to the whitelist in the config.py you will not be prompted otherwise you'll be warned before loading the plugin.
+If you add the plugins class name to the `ALLOWLISTED_PLUGINS` in the `.env` you will not be prompted otherwise you'll be warned before loading the plugin:
+
+```
+ALLOWLISTED_PLUGINS=example-plugin1,example-plugin2,example-plugin3
+```
 
 ## Setting Your Cache Type
 

--- a/autogpt/config/config.py
+++ b/autogpt/config/config.py
@@ -116,7 +116,13 @@ class Config(metaclass=Singleton):
         self.plugins_dir = os.getenv("PLUGINS_DIR", "plugins")
         self.plugins: List[AutoGPTPluginTemplate] = []
         self.plugins_openai = []
-        self.plugins_whitelist = []
+
+        plugins_allowlist = os.getenv("ALLOWLISTED_PLUGINS")
+        if plugins_allowlist:
+            plugins_allowlist=plugins_allowlist.split(",")
+            self.plugins_whitelist = plugins_allowlist
+        else:
+            self.plugins_whitelist = []
         self.plugins_blacklist = []
 
     def get_azure_deployment_id_for_model(self, model: str) -> str:


### PR DESCRIPTION
### Background
Adding Allowlisted Plugins via .env file improves user experience, because:
- Users do not have to edit code and produce unstaged changes
- .env is already commonly used and complies with common conventions
- Users are already familiar with editing the .env file


### Test Plan
Tested with various variations like empty list, one or multiple plugins
