### PR TITLE
Rename to allow and deny list

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -175,3 +175,10 @@ TW_CONSUMER_KEY=
 TW_CONSUMER_SECRET=
 TW_ACCESS_TOKEN=
 TW_ACCESS_TOKEN_SECRET=
+
+################################################################################
+### ALLOWLISTED PLUGINS
+################################################################################
+
+#ALLOWLISTED_PLUGINS - Sets the listed plugins that are allowed (Example: plugin1,plugin2,plugin3)
+ALLOWLISTED_PLUGINS=

--- a/README.md
+++ b/README.md
@@ -264,7 +264,11 @@ Drop the repo's zipfile in the plugins folder.
 
 ![Download Zip](https://raw.githubusercontent.com/BillSchumacher/Auto-GPT/master/plugin.png)
 
-If you add the plugins class name to the whitelist in the config.py you will not be prompted otherwise you'll be warned before loading the plugin.
+If you add the plugins class name to the `ALLOWLISTED_PLUGINS` in the `.env` you will not be prompted otherwise you'll be warned before loading the plugin:
+
+```
+ALLOWLISTED_PLUGINS=example-plugin1,example-plugin2,example-plugin3
+```
 
 ## Setting Your Cache Type
 

--- a/autogpt/config/config.py
+++ b/autogpt/config/config.py
@@ -116,7 +116,13 @@ class Config(metaclass=Singleton):
         self.plugins_dir = os.getenv("PLUGINS_DIR", "plugins")
         self.plugins: List[AutoGPTPluginTemplate] = []
         self.plugins_openai = []
-        self.plugins_whitelist = []
+
+        plugins_allowlist = os.getenv("ALLOWLISTED_PLUGINS")
+        if plugins_allowlist:
+            plugins_allowlist=plugins_allowlist.split(",")
+            self.plugins_whitelist = plugins_allowlist
+        else:
+            self.plugins_whitelist = []
         self.plugins_blacklist = []
 
     def get_azure_deployment_id_for_model(self, model: str) -> str:

--- a/autogpt/config/config.py
+++ b/autogpt/config/config.py
@@ -119,11 +119,10 @@ class Config(metaclass=Singleton):
 
         plugins_allowlist = os.getenv("ALLOWLISTED_PLUGINS")
         if plugins_allowlist:
-            plugins_allowlist=plugins_allowlist.split(",")
-            self.plugins_whitelist = plugins_allowlist
+            self.plugins_allowlist = plugins_allowlist.split(",")
         else:
-            self.plugins_whitelist = []
-        self.plugins_blacklist = []
+            self.plugins_allowlist = []
+        self.plugins_denylist = []
 
     def get_azure_deployment_id_for_model(self, model: str) -> str:
         """

--- a/autogpt/plugins.py
+++ b/autogpt/plugins.py
@@ -222,7 +222,7 @@ def scan_plugins(cfg: Config, debug: bool = False) -> List[AutoGPTPluginTemplate
                 if (
                     "_abc_impl" in a_keys
                     and a_module.__name__ != "AutoGPTPluginTemplate"
-                    and blacklist_whitelist_check(a_module.__name__, cfg)
+                    and denylist_allowlist_check(a_module.__name__, cfg)
                 ):
                     loaded_plugins.append(a_module())
     # OpenAI plugins
@@ -233,7 +233,7 @@ def scan_plugins(cfg: Config, debug: bool = False) -> List[AutoGPTPluginTemplate
                 manifests_specs, cfg, debug
             )
             for url, openai_plugin_meta in manifests_specs_clients.items():
-                if blacklist_whitelist_check(url, cfg):
+                if denylist_allowlist_check(url, cfg):
                     plugin = BaseOpenAIPlugin(openai_plugin_meta)
                     loaded_plugins.append(plugin)
 
@@ -244,8 +244,8 @@ def scan_plugins(cfg: Config, debug: bool = False) -> List[AutoGPTPluginTemplate
     return loaded_plugins
 
 
-def blacklist_whitelist_check(plugin_name: str, cfg: Config) -> bool:
-    """Check if the plugin is in the whitelist or blacklist.
+def denylist_allowlist_check(plugin_name: str, cfg: Config) -> bool:
+    """Check if the plugin is in the allowlist or denylist.
 
     Args:
         plugin_name (str): Name of the plugin.
@@ -254,12 +254,12 @@ def blacklist_whitelist_check(plugin_name: str, cfg: Config) -> bool:
     Returns:
         True or False
     """
-    if plugin_name in cfg.plugins_blacklist:
+    if plugin_name in cfg.plugins_denylist:
         return False
-    if plugin_name in cfg.plugins_whitelist:
+    if plugin_name in cfg.plugins_allowlist:
         return True
     ack = input(
         f"WARNNG Plugin {plugin_name} found. But not in the"
-        " whitelist... Load? (y/n): "
+        " allowlist... Load? (y/n): "
     )
     return ack.lower() == "y"

--- a/tests/unit/test_plugins.py
+++ b/tests/unit/test_plugins.py
@@ -2,7 +2,7 @@ import pytest
 
 from autogpt.config import Config
 from autogpt.plugins import (
-    blacklist_whitelist_check,
+    denylist_allowlist_check,
     inspect_zip_for_module,
     scan_plugins,
 )
@@ -19,56 +19,56 @@ def test_inspect_zip_for_module():
 
 
 @pytest.fixture
-def mock_config_blacklist_whitelist_check():
+def mock_config_denylist_allowlist_check():
     class MockConfig:
-        plugins_blacklist = ["BadPlugin"]
-        plugins_whitelist = ["GoodPlugin"]
+        plugins_denylist = ["BadPlugin"]
+        plugins_allowlist = ["GoodPlugin"]
 
     return MockConfig()
 
 
-def test_blacklist_whitelist_check_blacklist(
-    mock_config_blacklist_whitelist_check, monkeypatch
+def test_denylist_allowlist_check_denylist(
+    mock_config_denylist_allowlist_check, monkeypatch
 ):
     monkeypatch.setattr("builtins.input", lambda _: "y")
-    assert not blacklist_whitelist_check(
-        "BadPlugin", mock_config_blacklist_whitelist_check
+    assert not denylist_allowlist_check(
+        "BadPlugin", mock_config_denylist_allowlist_check
     )
 
 
-def test_blacklist_whitelist_check_whitelist(
-    mock_config_blacklist_whitelist_check, monkeypatch
+def test_denylist_allowlist_check_allowlist(
+    mock_config_denylist_allowlist_check, monkeypatch
 ):
     monkeypatch.setattr("builtins.input", lambda _: "y")
-    assert blacklist_whitelist_check(
-        "GoodPlugin", mock_config_blacklist_whitelist_check
+    assert denylist_allowlist_check(
+        "GoodPlugin", mock_config_denylist_allowlist_check
     )
 
 
-def test_blacklist_whitelist_check_user_input_yes(
-    mock_config_blacklist_whitelist_check, monkeypatch
+def test_denylist_allowlist_check_user_input_yes(
+    mock_config_denylist_allowlist_check, monkeypatch
 ):
     monkeypatch.setattr("builtins.input", lambda _: "y")
-    assert blacklist_whitelist_check(
-        "UnknownPlugin", mock_config_blacklist_whitelist_check
+    assert denylist_allowlist_check(
+        "UnknownPlugin", mock_config_denylist_allowlist_check
     )
 
 
-def test_blacklist_whitelist_check_user_input_no(
-    mock_config_blacklist_whitelist_check, monkeypatch
+def test_denylist_allowlist_check_user_input_no(
+    mock_config_denylist_allowlist_check, monkeypatch
 ):
     monkeypatch.setattr("builtins.input", lambda _: "n")
-    assert not blacklist_whitelist_check(
-        "UnknownPlugin", mock_config_blacklist_whitelist_check
+    assert not denylist_allowlist_check(
+        "UnknownPlugin", mock_config_denylist_allowlist_check
     )
 
 
-def test_blacklist_whitelist_check_user_input_invalid(
-    mock_config_blacklist_whitelist_check, monkeypatch
+def test_denylist_allowlist_check_user_input_invalid(
+    mock_config_denylist_allowlist_check, monkeypatch
 ):
     monkeypatch.setattr("builtins.input", lambda _: "invalid")
-    assert not blacklist_whitelist_check(
-        "UnknownPlugin", mock_config_blacklist_whitelist_check
+    assert not denylist_allowlist_check(
+        "UnknownPlugin", mock_config_denylist_allowlist_check
     )
 
 
@@ -85,8 +85,8 @@ def mock_config_openai_plugin():
     class MockConfig:
         plugins_dir = PLUGINS_TEST_DIR
         plugins_openai = [PLUGIN_TEST_OPENAI]
-        plugins_blacklist = ["AutoGPTPVicuna"]
-        plugins_whitelist = [PLUGIN_TEST_OPENAI]
+        plugins_denylist = ["AutoGPTPVicuna"]
+        plugins_allowlist = [PLUGIN_TEST_OPENAI]
 
     return MockConfig()
 
@@ -101,8 +101,8 @@ def mock_config_generic_plugin():
     class MockConfig:
         plugins_dir = PLUGINS_TEST_DIR
         plugins_openai = []
-        plugins_blacklist = []
-        plugins_whitelist = ["AutoGPTPVicuna"]
+        plugins_denylist = []
+        plugins_allowlist = ["AutoGPTPVicuna"]
 
     return MockConfig()
 


### PR DESCRIPTION
### Background
Using the wording `allowlist` and `denylist` ensures appropriate and production-ready wording for active repos like auto-gpt.